### PR TITLE
build: disable validation

### DIFF
--- a/installer/installer.wixproj
+++ b/installer/installer.wixproj
@@ -13,6 +13,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>OpenXT-Tools</OutputName>
     <OutputType>Package</OutputType>
+    <SuppressValidation>true</SuppressValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>


### PR DESCRIPTION
Documentation:
https://wixtoolset.org/documentation/manual/v3/overview/light.html

This may be a limitation of the validation system when the build is ran
as a service (buildbot-worker) without Admin privilege:
https://github.com/wixtoolset/issues/issues/3968

Turn off the validation until this is sorted.